### PR TITLE
Add defaults for RebuildMode and BlockMode

### DIFF
--- a/open-build-service-api/src/lib.rs
+++ b/open-build-service-api/src/lib.rs
@@ -49,19 +49,21 @@ impl std::fmt::Display for ApiError {
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Copy, Deserialize, Debug, Eq, PartialEq, Display)]
+#[derive(Clone, Copy, Default, Deserialize, Debug, Eq, PartialEq, Display)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum RebuildMode {
+    #[default]
     Transitive,
     Direct,
     Local,
 }
 
-#[derive(Clone, Copy, Deserialize, Debug, Eq, PartialEq, Display)]
+#[derive(Clone, Copy, Deserialize, Default, Debug, Eq, PartialEq, Display)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum BlockMode {
+    #[default]
     All,
     Local,
     Never,
@@ -70,7 +72,9 @@ pub enum BlockMode {
 #[derive(Deserialize, Debug)]
 pub struct RepositoryMeta {
     pub name: String,
+    #[serde(default)]
     pub rebuild: RebuildMode,
+    #[serde(default)]
     pub block: BlockMode,
 
     #[serde(default, rename = "arch")]

--- a/open-build-service-mock/src/api/source.rs
+++ b/open-build-service-mock/src/api/source.rs
@@ -168,8 +168,12 @@ impl Respond for ProjectMetaResponder {
         for (repo, arches) in &project.repos {
             let mut repository_xml = XMLElement::new("repository");
             repository_xml.add_attribute("name", repo);
-            repository_xml.add_attribute("rebuild", &project.rebuild.to_string());
-            repository_xml.add_attribute("block", &project.block.to_string());
+            if project.rebuild != Default::default() {
+                repository_xml.add_attribute("rebuild", &project.rebuild.to_string());
+            }
+            if project.block != Default::default() {
+                repository_xml.add_attribute("block", &project.block.to_string());
+            }
 
             let mut path_xml = XMLElement::new("path");
             path_xml.add_attribute("project", project_name);


### PR DESCRIPTION
rebuild and block are optional attributes in the `<repository />` element with defined default values. Reflect this in the deserialization as well otherwise the runner can't cope with repositories that don't have those attributes set in their meta.

For the mock this now leaves out those attributes if they have their default values. OBS doesn't reserialize meta configuration though, so meta's in the wild might still have the default values explicitly in which we now no longer test, but it seems unlikely for that to be an issue.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>