### PR TITLE
Add support for mocking package status details

### DIFF
--- a/open-build-service-api/tests/integration.rs
+++ b/open-build-service-api/tests/integration.rs
@@ -991,6 +991,8 @@ async fn test_build_jobhist() {
 
 #[tokio::test]
 async fn test_build_results() {
+    let details = "some details";
+
     let mock = start_mock().await;
 
     mock.add_project(TEST_PROJECT.to_owned());
@@ -1033,6 +1035,7 @@ async fn test_build_results() {
         TEST_PACKAGE_2.to_owned(),
         MockBuildStatus {
             code: MockPackageCode::Broken,
+            details: details.to_owned(),
             dirty: true,
         },
     );
@@ -1064,6 +1067,7 @@ async fn test_build_results() {
     let package2_status = &arch2_repo.statuses[0];
     assert_eq!(package2_status.package, TEST_PACKAGE_2);
     assert_eq!(package2_status.code, PackageCode::Broken);
+    assert_eq!(package2_status.details.as_ref().unwrap(), details);
     assert!(package2_status.dirty);
 
     let results = package_2.result().await.unwrap();
@@ -1189,6 +1193,8 @@ async fn test_build_binaries() {
 
 #[tokio::test]
 async fn test_build_status() {
+    let details = "details";
+
     let mock = start_mock().await;
 
     mock.add_project(TEST_PROJECT.to_owned());
@@ -1229,6 +1235,7 @@ async fn test_build_status() {
         TEST_PACKAGE_1.to_owned(),
         MockBuildStatus {
             code: MockPackageCode::Unknown,
+            details: details.to_owned(),
             dirty: true,
         },
     );
@@ -1237,6 +1244,7 @@ async fn test_build_status() {
 
     assert_eq!(status.package, TEST_PACKAGE_1);
     assert_eq!(status.code, PackageCode::Unknown);
+    assert_eq!(status.details.unwrap(), details);
     assert!(status.dirty);
 }
 

--- a/open-build-service-mock/src/api/build.rs
+++ b/open-build-service-mock/src/api/build.rs
@@ -234,6 +234,11 @@ fn package_status_xml(package_name: &str, status: &MockBuildStatus) -> XMLElemen
     if status.dirty {
         xml.add_attribute("dirty", "true");
     }
+
+    let mut details_xml = XMLElement::new("details");
+    details_xml.add_text(status.details.clone()).unwrap();
+    xml.add_child(details_xml).unwrap();
+
     xml
 }
 

--- a/open-build-service-mock/src/api/source.rs
+++ b/open-build-service-mock/src/api/source.rs
@@ -791,7 +791,7 @@ impl Respond for PackageSourceCommandResponder {
                 package_name,
                 comment,
                 &self.mock,
-                &mut *projects,
+                &mut projects,
             ),
             "branch" => do_branch(
                 request,
@@ -799,7 +799,7 @@ impl Respond for PackageSourceCommandResponder {
                 package_name,
                 comment,
                 &self.mock,
-                &mut *projects,
+                &mut projects,
             ),
             _ => ApiError::new(
                 StatusCode::NotFound,

--- a/open-build-service-mock/src/lib.rs
+++ b/open-build-service-mock/src/lib.rs
@@ -771,7 +771,7 @@ impl ObsMock {
         block: MockBlockMode,
     ) {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
         project.rebuild = rebuild;
         project.block = block;
     }
@@ -783,7 +783,7 @@ impl ObsMock {
         options: MockPackageOptions,
     ) {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
         let package = MockPackage::new_with_metadata(project_name, &package_name, options);
         project.packages.insert(package_name, package);
     }
@@ -845,7 +845,7 @@ impl ObsMock {
         entries: HashMap<String, MockEntry>,
     ) {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
         let package = get_package(project, package_name);
         package.add_revision(options, entries);
     }
@@ -860,7 +860,7 @@ impl ObsMock {
     ) {
         let mut projects = self.inner.projects.write().unwrap();
         let origin = get_package(
-            get_project(&mut *projects, &origin_project_name),
+            get_project(&mut projects, &origin_project_name),
             &origin_package_name,
         );
 
@@ -873,7 +873,7 @@ impl ObsMock {
             options,
         );
 
-        let project = get_project(&mut *projects, branched_project_name);
+        let project = get_project(&mut projects, branched_project_name);
         project.packages.insert(branched_package_name, package);
     }
 
@@ -885,7 +885,7 @@ impl ObsMock {
         code: MockRepositoryCode,
     ) {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
 
         project
             .repos
@@ -908,7 +908,7 @@ impl ObsMock {
         entry: MockJobHistoryEntry,
     ) {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
         ensure_source_package_exists(project, &entry.package);
 
         let repo = get_repo(project, repo_name, arch);
@@ -924,7 +924,7 @@ impl ObsMock {
         func: F,
     ) -> R {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
         ensure_source_package_exists(project, &package_name);
 
         let package = get_repo(project, repo_name, arch)
@@ -953,7 +953,7 @@ impl ObsMock {
         status: MockBuildStatus,
     ) {
         let mut projects = self.inner.projects.write().unwrap();
-        let project = get_project(&mut *projects, project_name);
+        let project = get_project(&mut projects, project_name);
         project.rebuild_status = status;
     }
 

--- a/open-build-service-mock/src/lib.rs
+++ b/open-build-service-mock/src/lib.rs
@@ -409,6 +409,7 @@ type ArchMap<Value> = HashMap<String, Value>;
 #[derive(Clone, Default)]
 pub struct MockBuildStatus {
     pub code: MockPackageCode,
+    pub details: String,
     pub dirty: bool,
 }
 


### PR DESCRIPTION
This was accidentally omitted before.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>