### PR TITLE
dependabot: Add dependabot config from obs-gitlab-runner

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,27 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    # Not yet supported. See <https://github.com/dependabot/dependabot-core/issues/4009>.
+    # versioning-strategy: "increase-if-necessary"
+    ignore:
+      - dependency-name: "tokio"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "serde"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
It's probably a good idea to enable dependabot for this repo.

cargo is printing the following:
> warning: the following packages contain code that will be rejected by a future version of Rust: quick-xml v0.22.0

