### PR TITLE
Upgrade wiremock to 0.6.2

### DIFF
--- a/open-build-service-mock/Cargo.toml
+++ b/open-build-service-mock/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 base16ct = { version = "0.1", features = ["std"] }
-http-types = "2.12"
+http = "1.2.0"
 md-5 = "0.10"
 quick-xml = { version = "0.23.1", features = [ "serialize" ] }
 rand = "0.8.5"
@@ -17,4 +17,5 @@ serde = "1.0.125"
 strum = "0.23"
 strum_macros = "0.23"
 xml-builder = "=0.5.3"
-wiremock = "0.5.22"
+wiremock = "0.6.2"
+base64ct = { version = "1.6.0", features = ["std"] }

--- a/open-build-service-mock/src/lib.rs
+++ b/open-build-service-mock/src/lib.rs
@@ -14,7 +14,6 @@ use api::{
     ProjectDeleteResponder, ProjectListingResponder, ProjectMetaResponder, RepoListingResponder,
 };
 
-use http_types::auth::BasicAuth;
 use md5::{Digest, Md5};
 use strum_macros::{Display, EnumString};
 use wiremock::{
@@ -25,6 +24,8 @@ use wiremock::{
 use xml_builder::XMLElement;
 
 mod api;
+
+use crate::api::BasicAuth;
 
 pub const ADMIN_USER: &str = "Admin";
 


### PR DESCRIPTION
wiremock replaces the `http-types` with the `http` crate.

I've adapt `struct BasicAuth` from `http-types` into the code. Alternatively wiremock provides `BasicAuthMatcher` which would be simpler but produce less concrete errors.

This MR is on top of https://github.com/collabora/open-build-service-rs/pull/11