### PR TITLE
mock: Switch out xml-builder with quick-xml

### DIFF
--- a/open-build-service-mock/Cargo.toml
+++ b/open-build-service-mock/Cargo.toml
@@ -16,6 +16,5 @@ rand = "0.8.5"
 serde = "1.0.125"
 strum = "0.23"
 strum_macros = "0.23"
-xml-builder = "=0.5.3"
 wiremock = "0.6.2"
 base64ct = { version = "1.6.0", features = ["std"] }


### PR DESCRIPTION
Last week `xml-builder` went from `0.5.3` to `0.5.4` making API changes which stopped CI from passing.

On crates.io `xml-builder` has 7 dependents vs `quick-xml`s 650.

This currently passes `cargo test`, however more should probably be done to verify this change doesn't produce different XML.

This MR is on top of #19 