### PR TITLE
Replace unmaintained structopt with clap

### DIFF
--- a/obsctl/Cargo.toml
+++ b/obsctl/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 open-build-service-api = { path = "../open-build-service-api" }
 oscrc = { path = "../oscrc" }
 url = { version = "2.5.4", features = [ "serde" ] }
-structopt = "0.3.21"
 anyhow = "1.0.40"
 tokio = { version = "1.35.0", features = [ "full" ] }
+clap = { version = "4.5.28", features = ["derive"] }
+clap_derive = "4.5.28"

--- a/obsctl/src/main.rs
+++ b/obsctl/src/main.rs
@@ -1,12 +1,12 @@
 use anyhow::{bail, Context, Result};
+use clap::Parser;
 use open_build_service_api::{Client, PackageCode, ResultListResult};
 use oscrc::Oscrc;
 use std::path::PathBuf;
 use std::time::Duration;
-use structopt::StructOpt;
 use url::Url;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct Package {
     project: String,
     package: String,
@@ -84,28 +84,28 @@ async fn monitor(client: Client, opts: Package) -> Result<()> {
     Ok(())
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     Monitor(Package),
 }
 
-#[derive(StructOpt)]
+#[derive(Parser, Debug)]
 struct Opts {
-    #[structopt(long, short)]
+    #[arg(long, short)]
     apiurl: Option<Url>,
-    #[structopt(long, short, default_value = "/home/sjoerd/.oscrc")]
+    #[arg(long, short, default_value = "/home/sjoerd/.oscrc")]
     config: PathBuf,
-    #[structopt(long, short, requires("pass"))]
+    #[arg(long, short, requires = "pass")]
     user: Option<String>,
-    #[structopt(long, short, requires("user"))]
+    #[arg(long, short, requires = "user")]
     pass: Option<String>,
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
     let (url, user, pass) = match opts {
         Opts {
             apiurl: Some(url),

--- a/open-build-service-api/Cargo.toml
+++ b/open-build-service-api/Cargo.toml
@@ -24,6 +24,7 @@ strum_macros = "0.23"
 open-build-service-mock = { path = "../open-build-service-mock" }
 oscrc = { path = "../oscrc" }
 url = { version = "2.5.4", features = [ "serde" ] }
-structopt = "0.3.21"
+clap = { version = "4.5.28", features = ["derive"] }
+clap_derive = "4.5.28"
 anyhow = "1.0.40"
 tokio = { version = "1.35.0", features = [ "full" ] }

--- a/open-build-service-api/examples/obsapi.rs
+++ b/open-build-service-api/examples/obsapi.rs
@@ -1,13 +1,13 @@
 use anyhow::{Context, Result};
+use clap::Parser;
 use futures::prelude::*;
 use open_build_service_api::{Client, PackageLogStreamOptions};
 use oscrc::Oscrc;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tokio::io::AsyncWriteExt;
 use url::Url;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct PackageFull {
     project: String,
     package: String,
@@ -15,13 +15,13 @@ struct PackageFull {
     arch: String,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct Package {
     project: String,
     package: String,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct BuildResult {
     project: String,
     package: Option<String>,
@@ -80,7 +80,7 @@ async fn result(client: Client, opts: BuildResult) -> Result<()> {
     Ok(())
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     Jobstatus(PackageFull),
     History(PackageFull),
@@ -90,23 +90,23 @@ enum Command {
     Result(BuildResult),
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Opts {
-    #[structopt(long, short)]
+    #[arg(long, short)]
     apiurl: Option<Url>,
-    #[structopt(long, short, default_value = "/home/sjoerd/.oscrc")]
+    #[arg(long, short, default_value = "/home/sjoerd/.oscrc")]
     config: PathBuf,
-    #[structopt(long, short, requires("pass"))]
+    #[arg(long, short, requires = "pass")]
     user: Option<String>,
-    #[structopt(long, short, requires("user"))]
+    #[arg(long, short, requires = "user")]
     pass: Option<String>,
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
     let (url, user, pass) = match opts {
         Opts {
             apiurl: Some(url),


### PR DESCRIPTION
Use `clap` and `clap_derive` to replace the functionality of `structopt` which is unmaintained.