### PR TITLE
obsctl: Report `Unknown` when build has no status

### DIFF
--- a/obsctl/src/main.rs
+++ b/obsctl/src/main.rs
@@ -21,13 +21,12 @@ struct MonitorData {
 
 impl MonitorData {
     fn from_result(r: ResultListResult, package: &str) -> Self {
-        let s = r
-            .get_status(package)
-            .expect("No status for current package");
         let code = if r.dirty {
             PackageCode::Unknown
         } else {
-            s.code
+            r.get_status(package)
+                .map(|s| s.code)
+                .unwrap_or(PackageCode::Unknown)
         };
         MonitorData {
             repository: r.repository,


### PR DESCRIPTION
Currently running `cargo run -- monitor` on my test setup panics with `No status for current package`.

The problem case is `armv7l` and is listed as having an unknown status in the web UI.