### PR TITLE
Request results filtered by arch and repository

### DIFF
--- a/obsctl/src/main.rs
+++ b/obsctl/src/main.rs
@@ -44,7 +44,7 @@ async fn monitor(client: Client, opts: Package) -> Result<()> {
     let p = client.project(opts.project).package(opts.package.clone());
     let mut last: Vec<MonitorData> = Vec::new();
     loop {
-        let result = p.result().await?;
+        let result = p.result(Default::default()).await?;
         for r in result.results {
             let data = MonitorData::from_result(r, &opts.package);
 

--- a/open-build-service-api/examples/obsapi.rs
+++ b/open-build-service-api/examples/obsapi.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::prelude::*;
-use open_build_service_api::{Client, PackageLogStreamOptions};
+use open_build_service_api::{Client, PackageLogStreamOptions, ResultOptions};
 use oscrc::Oscrc;
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
@@ -25,6 +25,10 @@ struct Package {
 struct BuildResult {
     project: String,
     package: Option<String>,
+    #[arg(long, short)]
+    repository: Option<String>,
+    #[arg(long, short)]
+    arch: Option<String>,
 }
 
 async fn jobstatus(client: Client, opts: PackageFull) -> Result<()> {
@@ -70,11 +74,15 @@ async fn list(client: Client, opts: Package) -> Result<()> {
 
 async fn result(client: Client, opts: BuildResult) -> Result<()> {
     let p = client.project(opts.project);
+    let result_options = ResultOptions {
+        repository: opts.repository,
+        arch: opts.arch,
+    };
     if let Some(package) = opts.package {
         let p = p.package(package);
-        println!("{:#?}", p.result().await);
+        println!("{:#?}", p.result(result_options).await);
     } else {
-        println!("{:#?}", p.result().await);
+        println!("{:#?}", p.result(result_options).await);
     }
 
     Ok(())

--- a/open-build-service-api/src/lib.rs
+++ b/open-build-service-api/src/lib.rs
@@ -305,6 +305,12 @@ pub struct CommitOptions {
 }
 
 #[derive(Clone, Debug, Default)]
+pub struct ResultOptions {
+    pub arch: Option<String>,
+    pub repository: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct BranchOptions {
     pub target_project: Option<String>,
     pub target_package: Option<String>,
@@ -1031,14 +1037,25 @@ impl<'a> PackageBuilder<'a> {
         self.client.post_request(u).await
     }
 
-    pub async fn result(&self) -> Result<ResultList> {
+    pub async fn result(&self, options: ResultOptions) -> Result<ResultList> {
         let mut u = self.client.base.clone();
         u.path_segments_mut()
             .map_err(|_| Error::InvalidUrl)?
             .push("build")
             .push(&self.project)
             .push("_result");
-        u.query_pairs_mut().append_pair("package", &self.package);
+
+        {
+            let mut q = u.query_pairs_mut();
+            q.append_pair("package", &self.package);
+            if let Some(repository) = &options.repository {
+                q.append_pair("repository", repository);
+            }
+            if let Some(arch) = &options.arch {
+                q.append_pair("arch", arch);
+            }
+        }
+
         self.client.request(u).await
     }
 }
@@ -1088,13 +1105,24 @@ impl<'a> ProjectBuilder<'a> {
         self.client.request(u).await
     }
 
-    pub async fn result(&self) -> Result<ResultList> {
+    pub async fn result(&self, options: ResultOptions) -> Result<ResultList> {
         let mut u = self.client.base.clone();
         u.path_segments_mut()
             .map_err(|_| Error::InvalidUrl)?
             .push("build")
             .push(&self.project)
             .push("_result");
+
+        {
+            let mut q = u.query_pairs_mut();
+            if let Some(repository) = &options.repository {
+                q.append_pair("repository", repository);
+            }
+            if let Some(arch) = &options.arch {
+                q.append_pair("arch", arch);
+            }
+        }
+
         self.client.request(u).await
     }
 

--- a/open-build-service-api/tests/integration.rs
+++ b/open-build-service-api/tests/integration.rs
@@ -1046,7 +1046,7 @@ async fn test_build_results() {
         .project(TEST_PROJECT.to_owned())
         .package(TEST_PACKAGE_2.to_owned());
 
-    let results = project.result().await.unwrap();
+    let results = project.result(Default::default()).await.unwrap();
     let (arch1_repo, arch2_repo) = get_results_by_arch(results);
 
     assert_eq!(arch1_repo.project, TEST_PROJECT);
@@ -1070,7 +1070,23 @@ async fn test_build_results() {
     assert_eq!(package2_status.details.as_ref().unwrap(), details);
     assert!(package2_status.dirty);
 
-    let results = package_2.result().await.unwrap();
+    // Test project filter
+    let results = project
+        .result(ResultOptions {
+            repository: Some(TEST_REPO.to_owned()),
+            arch: Some(TEST_ARCH_1.to_owned()),
+        })
+        .await
+        .unwrap();
+
+    let arch1_repo = &results.results[0];
+    assert_eq!(arch1_repo.project, TEST_PROJECT);
+    assert_eq!(arch1_repo.repository, TEST_REPO);
+    assert_eq!(arch1_repo.arch, TEST_ARCH_1);
+    assert_eq!(arch1_repo.code, RepositoryCode::Building);
+    assert_eq!(results.results.len(), 1);
+
+    let results = package_2.result(Default::default()).await.unwrap();
     let (arch1_repo, arch2_repo) = get_results_by_arch(results);
 
     assert_eq!(arch1_repo.statuses.len(), 0);
@@ -1089,7 +1105,7 @@ async fn test_build_results() {
         MockBuildStatus::new(MockPackageCode::Broken),
     );
 
-    let results = project.result().await.unwrap();
+    let results = project.result(Default::default()).await.unwrap();
     let (arch1_repo, _) = get_results_by_arch(results);
 
     let package2_arch2 = arch1_repo
@@ -1100,7 +1116,7 @@ async fn test_build_results() {
     assert_eq!(package2_arch2.package, TEST_PACKAGE_2);
     assert_eq!(package2_arch2.code, PackageCode::Broken);
 
-    let results = package_2.result().await.unwrap();
+    let results = package_2.result(Default::default()).await.unwrap();
     let (arch1_repo, arch2_repo) = get_results_by_arch(results);
 
     assert_eq!(arch1_repo.statuses.len(), 1);
@@ -1108,6 +1124,22 @@ async fn test_build_results() {
 
     assert_eq!(arch1_repo.statuses[0].package, TEST_PACKAGE_2);
     assert_eq!(arch2_repo.statuses[0].package, TEST_PACKAGE_2);
+
+    // Test package filter
+    let results = package_2
+        .result(ResultOptions {
+            repository: Some(TEST_REPO.to_owned()),
+            arch: Some(TEST_ARCH_2.to_owned()),
+        })
+        .await
+        .unwrap();
+
+    let arch2_repo = &results.results[0];
+    assert_eq!(arch2_repo.project, TEST_PROJECT);
+    assert_eq!(arch2_repo.repository, TEST_REPO);
+    assert_eq!(arch2_repo.code, RepositoryCode::Broken);
+    assert_eq!(arch2_repo.statuses.len(), 1);
+    assert_eq!(results.results.len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
For use [here](https://github.com/collabora/obs-gitlab-runner/blob/a9a799432896bbc0474e7238b475d741e79bc76b/src/monitor.rs#L107).

Currently this adds an `ResultOptions` argument to the `result` methods however I'm wondering whether moving to using builders would provide a nicer API.