### PR TITLE
Add support for updating package meta using a DOM

### DIFF
--- a/open-build-service-api/Cargo.toml
+++ b/open-build-service-api/Cargo.toml
@@ -19,6 +19,9 @@ bytes = "1.0.1"
 base16ct = { version = "0.1", features = ["std"] }
 md-5 = "0.10"
 strum_macros = "0.23"
+tracing = "0.1"
+xml_dom = "0.2.8"
+tokio = "1.35.0"
 
 [dev-dependencies]
 open-build-service-mock = { path = "../open-build-service-mock" }


### PR DESCRIPTION
This is a WIP alternative to #25 using `xml_dom`

It currently provides the ability to update the package meta to disable a build based on target repository and architecture.

I'm not finding the `xml_dom` API particularly friendly.
I've looked into `minidom` which is unsuitable as it mandates namespaces.