### PR TITLE
actions: Improve clippy handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
         with:
           toolchain: "1.86"
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - uses: clechasseur/rs-clippy-check@v4.0.5
+        with:
+          args: --all-targets --all-features -- -D warnings
 
   clippy-latest:
     name: cargo clippy latest
@@ -62,7 +64,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - uses: clechasseur/rs-clippy-check@v4.0.5
+        with:
+          args: --all-targets --all-features
 
   minimal-dependencies:
     name: minimal direct dependencies


### PR DESCRIPTION
Switch to wrapping clippy so the annotations come nicely into the review flow even if the job themselves itself doesn't  fail.  I ended up going with `clechasseur/rs-clippy-check` as that seems the most well-maintained fork of `actions-rs/clippy-check`