### PR TITLE
Various improvements to link handling

### DIFF
--- a/open-build-service-api/src/lib.rs
+++ b/open-build-service-api/src/lib.rs
@@ -202,14 +202,16 @@ pub struct LinkInfo {
     pub project: String,
     #[serde(rename = "@package")]
     pub package: String,
-    #[serde(rename = "@srcmd5")]
-    pub srcmd5: String,
-    #[serde(rename = "@xsrcmd5")]
-    pub xsrcmd5: String,
-    #[serde(rename = "@lsrcmd5")]
-    pub lsrcmd5: String,
+    #[serde(default, rename = "@srcmd5")]
+    pub srcmd5: Option<String>,
+    #[serde(default, rename = "@xsrcmd5")]
+    pub xsrcmd5: Option<String>,
+    #[serde(default, rename = "@lsrcmd5")]
+    pub lsrcmd5: Option<String>,
     #[serde(default, rename = "@missingok")]
     pub missingok: bool,
+    #[serde(default, rename = "@error")]
+    pub error: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/open-build-service-api/tests/integration.rs
+++ b/open-build-service-api/tests/integration.rs
@@ -297,8 +297,11 @@ async fn test_source_list() {
     assert_eq!(dir.rev.unwrap(), "1");
     assert_eq!(dir.vrev.unwrap(), "1");
     assert_eq!(dir.srcmd5, branch_srcmd5);
-    assert_eq!(dir.entries.len(), 1);
+    assert_eq!(dir.entries.len(), 2);
     assert_eq!(dir.linkinfo.len(), 1);
+
+    assert!(dir.entries.iter().any(|e| e.name == "_link"));
+    assert!(dir.entries.iter().any(|e| e.name == "test"));
 
     let linkinfo = &dir.linkinfo[0];
     assert_eq!(linkinfo.project, TEST_PROJECT);

--- a/open-build-service-api/tests/integration.rs
+++ b/open-build-service-api/tests/integration.rs
@@ -287,7 +287,9 @@ async fn test_source_list() {
         TEST_PACKAGE_2.to_owned(),
         MockBranchOptions {
             srcmd5: branch_srcmd5.clone(),
-            xsrcmd5: branch_xsrcmd5.clone(),
+            link_resolution: MockLinkResolution::Available {
+                xsrcmd5: branch_xsrcmd5.clone(),
+            },
             ..Default::default()
         },
     );
@@ -306,9 +308,42 @@ async fn test_source_list() {
     let linkinfo = &dir.linkinfo[0];
     assert_eq!(linkinfo.project, TEST_PROJECT);
     assert_eq!(linkinfo.package, TEST_PACKAGE_1);
-    assert_eq!(linkinfo.srcmd5, srcmd5);
-    assert_eq!(linkinfo.lsrcmd5, branch_srcmd5);
-    assert_eq!(linkinfo.xsrcmd5, branch_xsrcmd5);
+    assert_eq!(linkinfo.srcmd5.as_ref().unwrap(), &srcmd5);
+    assert_eq!(linkinfo.lsrcmd5.as_ref().unwrap(), &branch_srcmd5);
+    assert_eq!(linkinfo.xsrcmd5.as_ref().unwrap(), &branch_xsrcmd5);
+
+    mock.branch(
+        TEST_PROJECT.to_owned(),
+        TEST_PACKAGE_1.to_owned(),
+        TEST_PROJECT,
+        TEST_PACKAGE_2.to_owned(),
+        MockBranchOptions {
+            srcmd5: branch_srcmd5.clone(),
+            link_resolution: MockLinkResolution::Error {
+                error: "an error".to_owned(),
+            },
+            ..Default::default()
+        },
+    );
+
+    let dir = package_2.list(None).await.unwrap();
+
+    assert_eq!(dir.rev.unwrap(), "1");
+    assert_eq!(dir.vrev.unwrap(), "1");
+    assert_eq!(dir.srcmd5, branch_srcmd5);
+    assert_eq!(dir.entries.len(), 2);
+    assert_eq!(dir.linkinfo.len(), 1);
+
+    assert!(dir.entries.iter().any(|e| e.name == "_link"));
+    assert!(dir.entries.iter().any(|e| e.name == "test"));
+
+    let linkinfo = &dir.linkinfo[0];
+    assert_eq!(linkinfo.project, TEST_PROJECT);
+    assert_eq!(linkinfo.package, TEST_PACKAGE_1);
+    assert_eq!(linkinfo.srcmd5, None);
+    assert_eq!(linkinfo.lsrcmd5, None);
+    assert_eq!(linkinfo.xsrcmd5, None);
+    assert_eq!(linkinfo.error.as_ref().unwrap(), "an error");
 }
 
 #[tokio::test]

--- a/open-build-service-mock/src/lib.rs
+++ b/open-build-service-mock/src/lib.rs
@@ -159,7 +159,7 @@ struct MockLinkInfo {
     baserev: String,
     srcmd5: String,
     lsrcmd5: String,
-    xsrcmd5: String,
+    link_resolution: MockLinkResolution,
     missingok: bool,
 }
 
@@ -349,7 +349,7 @@ impl MockPackage {
             package: origin_package_name,
             baserev: origin_srcmd5.clone(),
             srcmd5: origin_srcmd5,
-            xsrcmd5: options.xsrcmd5,
+            link_resolution: options.link_resolution,
             lsrcmd5: options.srcmd5.clone(),
             missingok: options.missingok,
         };
@@ -417,9 +417,15 @@ impl MockPackage {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum MockLinkResolution {
+    Available { xsrcmd5: String },
+    Error { error: String },
+}
+
 pub struct MockBranchOptions {
     pub srcmd5: String,
-    pub xsrcmd5: String,
+    pub link_resolution: MockLinkResolution,
     pub user: String,
     pub time: SystemTime,
     pub comment: Option<String>,
@@ -430,7 +436,9 @@ impl Default for MockBranchOptions {
     fn default() -> Self {
         Self {
             srcmd5: random_md5(),
-            xsrcmd5: random_md5(),
+            link_resolution: MockLinkResolution::Available {
+                xsrcmd5: random_md5(),
+            },
             time: SystemTime::now(),
             user: ADMIN_USER.to_owned(),
             comment: None,


### PR DESCRIPTION
Adds the `_link` entry to file listings, treats removal of it as a link break, and fixes deserialization errors on broken links.