### PR TITLE
Fix dependencies and fill in some metadata to prepare for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.86"
+          toolchain: "1.88"
       - run: cargo check --all-targets --all-features
 
   fmt:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.86"
+          toolchain: "1.88"
           components: rustfmt
       - run: cargo fmt --all --check
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.86"
+          toolchain: "1.88"
       - run: cargo test --all-targets --all-features
 
   clippy:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.86"
+          toolchain: "1.88"
           components: clippy
       - uses: clechasseur/rs-clippy-check@v4.0.5
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,17 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,12 +398,12 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.10.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
  "tokio",
 ]
@@ -2921,12 +2910,11 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "async-trait",
  "base64",
  "deadpool",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ members = [
   "open-build-service-api",
   "open-build-service-mock"
 ]
+
+[workspace.package]
+repository = "https://github.com/collabora/open-build-service-rs"
+homepage = "https://github.com/collabora/open-build-service-rs"

--- a/open-build-service-api/Cargo.toml
+++ b/open-build-service-api/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Client for the Open Build Service API"
+repository.workspace = true
+homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/open-build-service-mock/Cargo.toml
+++ b/open-build-service-mock/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Mock crate for the Open Build Service API"
+repository.workspace = true
+homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/open-build-service-mock/Cargo.toml
+++ b/open-build-service-mock/Cargo.toml
@@ -16,5 +16,5 @@ rand = "0.9.2"
 serde = "1.0.217"
 strum = "0.27"
 strum_macros = "0.23"
-wiremock = "0.6.2"
+wiremock = "0.6.5"
 base64ct = { version = "1.6.0", features = ["std"] }


### PR DESCRIPTION
The publish dry-run was failing due to the dependency issues, and filling in some basic metadata avoids getting warnings from that too.