### PR TITLE
Set a nonempty user-agent

### DIFF
--- a/open-build-service-api/src/lib.rs
+++ b/open-build-service-api/src/lib.rs
@@ -1291,7 +1291,10 @@ impl Client {
             base: url,
             user,
             pass,
-            client: reqwest::Client::new(),
+            client: reqwest::ClientBuilder::new()
+                .user_agent(concat!("open-build-service-rs/", env!("CARGO_PKG_VERSION")))
+                .build()
+                .unwrap(),
         }
     }
 


### PR DESCRIPTION
Some proxies really don't like this to be blank, causing them to reject every request.