### PR TITLE
Improve dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,27 +1,66 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
----
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-    # Not yet supported. See <https://github.com/dependabot/dependabot-core/issues/4009>.
-    # versioning-strategy: "increase-if-necessary"
-    ignore:
-      - dependency-name: "tokio"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "serde"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  labels:
+  - dependencies
+- package-ecosystem: cargo
+  directory: /
+  schedule:
+    interval: daily
+  ignore:
+  - dependency-name: anyhow
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: base16ct
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: base64ct
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: bytes
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: clap
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: clap_derive
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: http
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: secret-service
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: serde
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: thiserror
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: tokio
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: url
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-patch
+  labels:
+  - dependencies


### PR DESCRIPTION
Run cargo-dependabot-if-necessary to create a dependabot config which ignores updates for semver compatible versions