### PR TITLE
mock: Enable serde's derive feature

### DIFF
--- a/open-build-service-mock/Cargo.toml
+++ b/open-build-service-mock/Cargo.toml
@@ -17,7 +17,7 @@ http = "1.2.0"
 md-5 = "0.11"
 quick-xml = { version = "0.39", features = [ "serialize" ] }
 rand = "0.10.1"
-serde = "1.0.217"
+serde = { version = "1.0.217", features = ["derive"] }
 strum = "0.28"
 strum_macros = "0.28"
 wiremock = "0.6.5"


### PR DESCRIPTION
This accidentally worked before because all our consumers of the mock create themselves enable this feature.