### PR TITLE
Fix infinite looping when the log response is a single empty data chunk

### DIFF
--- a/open-build-service-api/src/lib.rs
+++ b/open-build-service-api/src/lib.rs
@@ -700,6 +700,9 @@ impl Stream for PackageLogStream<'_> {
                     match ready!(stream.as_mut().poll_next(cx)) {
                         Some(Err(e)) => return Poll::Ready(Some(Err(e.into()))),
                         Some(Ok(b)) => {
+                            if b.is_empty() {
+                                continue;
+                            }
                             me.offset += b.len();
                             *gotdata = true;
                             return Poll::Ready(Some(Ok(b)));


### PR DESCRIPTION
On HTTP/2, when the response is empty, some servers will return a singular empty DATA frame instead of simply omitting it (leaving only e.g. the HEADERS frame with EOS set). In that case, reqwest forwards the empty frame's contents directly to us...but that would get counted as if actual data had been received and cause `gotdata` to be set. Then, when we hit the actual stream end on the next iteration, the code mistakenly believed data was actually received and would re-send the exact same request, causing this entire process to repeat.

Why didn't this appear before? On reqwest 0.12, w/ the default native TLS backend, ALPN was disabled by default, which effectively meant that connections would never get upgraded to HTTP/2. With the update to 0.13, both TLS backends now have ALPN enabled (in addition to the rustls-by-default switch), causing us to hit this potential edge case with HTTP/2 servers.